### PR TITLE
Close #437: Send `X-Request-Timestamp` on manual firmware update check

### DIFF
--- a/src/page_software_update.mjs
+++ b/src/page_software_update.mjs
@@ -177,7 +177,7 @@ class PageSoftwareUpdate {
     await Network.waitWhileInProgress()
 
     // Get current Unix timestamp in seconds
-    const unixTimestamp = Math.floor(Date.now() / 1000).toString();
+    const unixTimestamp = Math.floor(Date.now() / 1000).toString()
 
     Network.httpGetJson('/firmware_update.json', 40000,
         { 'extra_headers': { 'X-Request-Timestamp': unixTimestamp } }).then((data) => {

--- a/src/page_software_update.mjs
+++ b/src/page_software_update.mjs
@@ -176,7 +176,11 @@ class PageSoftwareUpdate {
     GwStatus.stopCheckingStatus()
     await Network.waitWhileInProgress()
 
-    Network.httpGetJson('/firmware_update.json', 40000).then((data) => {
+    // Get current Unix timestamp in seconds
+    const unixTimestamp = Math.floor(Date.now() / 1000).toString();
+
+    Network.httpGetJson('/firmware_update.json', 40000,
+        { 'extra_headers': { 'X-Request-Timestamp': unixTimestamp } }).then((data) => {
       this.#on_get_latest_release_info(data)
     }).catch((err) => {
       console.log(log_wrap(`GET firmware_update.json failed: ${err}`))


### PR DESCRIPTION
## Motivation
Manual firmware update checks issued from the Web UI hit
`https://network.ruuvi.com/firmwareupdate` (or a user-defined HTTPS server).
If the gateway's real-time clock is not synchronised — for example because
NTP is disabled, outbound NTP is blocked, or the device has just booted —
the TLS handshake fails: certificate validity windows cannot be checked
against an unset clock. The result is that "Check for updates" appears to
be broken on otherwise healthy gateways.

For unattended/automatic update checks the only available workaround is to
point the gateway at a plain-HTTP server. For the **manual** check, however,
the browser already has the correct wall-clock, so we can simply hand it to
the firmware and let it set the system time before opening the outbound TLS
connection.

## Changes

### `src/page_software_update.mjs`
* Before issuing `GET /firmware_update.json`, compute the current Unix
  epoch in seconds:
  ```js
  const unixTimestamp = Math.floor(Date.now() / 1000).toString();
  ```
* Pass it through the existing extra_headers option of Network.httpGetJson:
  ```js
  Network.httpGetJson('/firmware_update.json', 40000,
      { 'extra_headers': { 'X-Request-Timestamp': unixTimestamp } })
  ```

No other modules are touched. Network.fetch_json already merges options.extra_headers into the outgoing request headers, so no plumbing changes are required.

## Companion change

Firmware-side parsing of the header lives in the esp32-wifi-manager component — see issue [#333](https://github.com/ruuvi/esp32-wifi-manager/issues/333) and its accompanying PR. The firmware reads the header in http_server_handle_req_get and exposes the value via http_server_get_request_timestamp(); the application then calls settimeofday() before fetching firmware metadata.

## Compatibility

* **Older firmware**: ignores unknown headers, so the behaviour is unchanged (still fails if the clock is not set, exactly as today).
* **New firmware**: seeds its clock from the header and successfully completes the TLS handshake to the update server.

