### PR TITLE
ci: #446 Update github workflow actions and pin them to commit SHAs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Close #446
Update actions/checkout to v7.0.1 and actions/setup-node to v7.0.0 in the test workflow.

Pin both actions to immutable full-length commit SHAs while retaining release tags in comments for maintainability.

| Repository                        |  Tag   |  Commit SHA                              |  Commit creation date   |
|-----------------------------------|--------|------------------------------------------|-------------------------|
| actions/checkout                  | v7.0.1 | 3d3c42e5aac5ba805825da76410c181273ba90b1 | 2026-07-17 18:45:11 UTC |
| actions/setup-node                | v7.0.0 | 820762786026740c76f36085b0efc47a31fe5020 | 2026-07-14 02:38:27 UTC |
